### PR TITLE
Bcrypt password manager - checkpw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.dll
 __pycache__
 src/*.egg-info
-
+.eggs
 .installed.cfg
 .tox
 bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
 #   pending 3.3-compatible release
 install:
     - pip install .
+    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then pip install bcrypt; fi
 script:
     - python setup.py test -q
 notifications:

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -4,7 +4,7 @@ Using :mod:`zope.password`
 This package provides a password manager mechanism. Password manager
 is an utility object that can encode and check encoded
 passwords. Beyond the generic interface, this package also provides
-seven implementations:
+eight implementations:
 
 :class:`zope.password.password.PlainTextPasswordManager`
 
@@ -31,9 +31,9 @@ seven implementations:
 
 :class:`zope.password.password.SSHAPasswordManager`
 
-   the most secure password manager that is strong against dictionary
-   attacks. It's basically SHA1-encoding password manager which also
-   incorporates a salt into the password when encoding it.
+   A password manager that is strong against dictionary attacks. It's
+   basically SHA1-encoding password manager which also incorporates a
+   salt into the password when encoding it.
 
 :class:`zope.password.password.CryptPasswordManager`
 
@@ -48,16 +48,22 @@ seven implementations:
    PASSWORD function in MySQL versions before 4.1.  Note that this method
    results in a very weak 16-byte hash.
 
+:class:`zope.password.password.BCRYPTPasswordManager`
+
+   A manager implementing the bcrypt hashing scheme. Only available if
+   the bcrypt_ module is installed.  This manager is considered the
+   most secure.
+
 The ``Crypt``, ``MD5``, ``SMD5``, ``SHA`` and ``SSHA`` password managers
 are all compatible with RFC 2307 LDAP implementations of the same password
 encoding schemes.
 
-.. note:: 
-   It is strongly recommended to use SSHAPasswordManager, as it's the
+.. note::
+   It is strongly recommended to use the BCRYPTPasswordManager, as it's the
    most secure.
 
-The package also provides a script, :command:`zpasswd`,to generate principal
-entries in typical ``site.zcml`` files.
+The package also provides a script, :command:`zpasswd`, to generate
+principal entries in typical ``site.zcml`` files.
 
 Password Manager Interfaces
 ---------------------------
@@ -138,7 +144,7 @@ A typical :command:`zpasswd` session might look like:
 
 .. code-block:: sh
 
-   $ ./bin/zpasswd 
+   $ ./bin/zpasswd
 
    Please choose an id for the principal.
 
@@ -158,21 +164,23 @@ A typical :command:`zpasswd` session might look like:
 
     1. Plain Text
     2. MD5
-    3. SHA1
-    4. SSHA
+    3. SMD5
+    4. SHA1
+    5. SSHA
+    6. BCRYPT
 
-   Password Manager Number [4]: 
-   SSHA password manager selected
+   Password Manager Number [6]:
+   BCRYPT password manager selected
 
 
    Please provide a password for the principal.
 
-   Password: 
-   Verify password: 
+   Password:
+   Verify password:
 
    Please provide an optional description for the principal.
 
-   Description: The main foo 
+   Description: The main foo
 
    ============================================
    Principal information for inclusion in ZCML:
@@ -181,7 +189,9 @@ A typical :command:`zpasswd` session might look like:
        id="foo"
        title="The Foo"
        login="foo"
-       password="{SSHA}Zi_Lsz7Na3bS5rz4Aer-9TbqomXD2f3T"
+       password="$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK"
        description="The main foo"
-       password_manager="SSHA"
+       password_manager="BCRYPT"
        />
+
+.. _bcrypt: https://pypi.python.org/pypi/bcrypt

--- a/docs/narrative.rst
+++ b/docs/narrative.rst
@@ -189,7 +189,7 @@ A typical :command:`zpasswd` session might look like:
        id="foo"
        title="The Foo"
        login="foo"
-       password="$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK"
+       password="{BCRYPT}$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK"
        description="The main foo"
        password_manager="BCRYPT"
        />

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ setup(name='zope.password',
       author_email='zope-dev@zope.org',
       description='Password encoding and checking utilities',
       long_description=(
-        read('README.rst')
-        + '\n\n' +
-        read('CHANGES.rst')
-        ),
+          read('README.rst')
+          + '\n\n' +
+          read('CHANGES.rst')
+          ),
       url='http://pypi.python.org/pypi/zope.password',
       license='ZPL 2.1',
       classifiers = [
@@ -67,9 +67,10 @@ setup(name='zope.password',
           'Framework :: Zope3'],
       keywords='zope authentication password zpasswd',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       extras_require=dict(vocabulary=['zope.schema'],
                           test=['zope.schema', 'zope.testing'],
+                          bcrypt=['bcrypt'],
                           ),
       namespace_packages=['zope'],
       install_requires=['setuptools',
@@ -77,14 +78,14 @@ setup(name='zope.password',
                         'zope.configuration',
                         'zope.interface',
                         ],
-      tests_require = [
+      tests_require=[
           'zope.schema',
           'zope.testing',
           'zope.testrunner',
           ],
-      test_suite = '__main__.alltests',
-      include_package_data = True,
-      zip_safe = False,
+      test_suite='__main__.alltests',
+      include_package_data=True,
+      zip_safe=False,
       entry_points="""
       [console_scripts]
       zpasswd = zope.password.zpasswd:main

--- a/src/zope/password/compat.py
+++ b/src/zope/password/compat.py
@@ -1,0 +1,10 @@
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+    bytes_type = bytes
+else:
+    text_type = unicode
+    bytes_type = str

--- a/src/zope/password/configure.zcml
+++ b/src/zope/password/configure.zcml
@@ -39,12 +39,20 @@
       factory=".legacy.MySQLPasswordManager"
       />
 
+  <configure zcml:condition="installed bcrypt">
+    <utility
+       name="BCRYPT"
+       provides=".interfaces.IMatchingPasswordManager"
+       factory=".password.BCRYPTPasswordManager"
+       />
+  </configure>
+
   <configure zcml:condition="installed crypt">
-  <utility
-      name="Crypt"
-      provides=".interfaces.IMatchingPasswordManager"
-      factory=".legacy.CryptPasswordManager"
-      />
+    <utility
+        name="Crypt"
+        provides=".interfaces.IMatchingPasswordManager"
+        factory=".legacy.CryptPasswordManager"
+        />
   </configure>
 
   <utility
@@ -58,19 +66,19 @@
     <class class=".password.PlainTextPasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
-  
+
     <class class=".password.MD5PasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
-  
+
     <class class=".password.SMD5PasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
-  
+
     <class class=".password.SHA1PasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
-  
+
     <class class=".password.SSHAPasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
@@ -78,6 +86,12 @@
     <class class=".legacy.MySQLPasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />
     </class>
+
+    <configure zcml:condition="installed bcrypt">
+      <class class=".password.BCRYPTPasswordManager">
+        <allow interface=".interfaces.IMatchingPasswordManager" />
+      </class>
+    </configure>
 
     <configure zcml:condition="installed crypt">
       <class class=".legacy.CryptPasswordManager">

--- a/src/zope/password/password.py
+++ b/src/zope/password/password.py
@@ -514,8 +514,6 @@ if bcrypt is not None:
             def _clean_hashed(self, hashed_password):
                 return self._to_bytes(hashed_password, 'ascii')
 
-            gensalt = staticmethod(bcrypt.gensalt)
-
             def checkPassword(self, hashed_password, clear_password):
                 """Check a `hashed_password` against a `clear password`.
 
@@ -550,7 +548,7 @@ if bcrypt is not None:
                 :returns: The encoded password as a byte-siring.
                 """
                 if salt is None:
-                    salt = self.gensalt()
+                    salt = bcrypt.gensalt()
                 salt = self._clean_hashed(salt)
                 pw = self._clean_clear(password)
                 return self._prefix + bcrypt.hashpw(pw, salt=salt)

--- a/src/zope/password/password.py
+++ b/src/zope/password/password.py
@@ -531,9 +531,11 @@ if bcrypt is not None:
                 pw_bytes = self._clean_clear(clear_password)
                 pw_hash = hashed_password[len(self._prefix):]
                 try:
-                    return bcrypt.hashpw(pw_bytes, pw_hash) == pw_hash
+                    ok = bcrypt.checkpw(pw_bytes, pw_hash)
                 except ValueError:
-                    return False
+                    # invalid salt
+                    ok = False
+                return ok
 
             def encodePassword(self, password, salt=None):
                 """Encode a `password`, with an optional `salt`.

--- a/src/zope/password/password.py
+++ b/src/zope/password/password.py
@@ -15,24 +15,25 @@
 """
 __docformat__ = 'restructuredtext'
 
-from base64 import standard_b64encode
 from base64 import standard_b64decode
+from base64 import standard_b64encode
 from base64 import urlsafe_b64decode
 from binascii import a2b_hex
+from codecs import getencoder
 from hashlib import md5, sha1
 from os import urandom
-from codecs import getencoder
+
+try:
+    import bcrypt
+except ImportError:
+    bcrypt = None
 
 from zope.interface import implementer
+from zope.password.compat import text_type
 from zope.password.interfaces import IMatchingPasswordManager
 
 _encoder = getencoder("utf-8")
 
-try:
-    unicode
-except NameError:
-    # Py3: Define unicode.
-    unicode = str
 
 @implementer(IMatchingPasswordManager)
 class PlainTextPasswordManager(object):
@@ -67,7 +68,7 @@ class PlainTextPasswordManager(object):
 
 
     def encodePassword(self, password):
-        if isinstance(password, unicode):
+        if isinstance(password, text_type):
             password = password.encode('utf-8')
         return password
 
@@ -166,7 +167,7 @@ class SSHAPasswordManager(PlainTextPasswordManager):
     def encodePassword(self, password, salt=None):
         if salt is None:
             salt = urandom(4)
-        elif isinstance(salt, unicode):
+        elif isinstance(salt, text_type):
             salt = salt.encode('utf-8')
         hash = sha1(_encoder(password)[0])
         hash.update(salt)
@@ -176,7 +177,7 @@ class SSHAPasswordManager(PlainTextPasswordManager):
         # standard_b64decode() cannot handle unicode input string. We
         # encode to ascii. This is safe as the encoded_password string
         # should not contain non-ascii characters anyway.
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         encoded_password = encoded_password[6:]
         if b'_' in encoded_password or b'-' in encoded_password:
@@ -189,7 +190,7 @@ class SSHAPasswordManager(PlainTextPasswordManager):
         return encoded_password == self.encodePassword(password, salt)[6:]
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password.startswith(b'{SSHA}')
 
@@ -266,21 +267,21 @@ class SMD5PasswordManager(PlainTextPasswordManager):
     def encodePassword(self, password, salt=None):
         if salt is None:
             salt = urandom(4)
-        elif isinstance(salt, unicode):
+        elif isinstance(salt, text_type):
             salt = salt.encode('utf-8')
         hash = md5(_encoder(password)[0])
         hash.update(salt)
         return b'{SMD5}' + standard_b64encode(hash.digest() + salt)
 
     def checkPassword(self, encoded_password, password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         byte_string = standard_b64decode(encoded_password[6:])
         salt = byte_string[16:]
         return encoded_password == self.encodePassword(password, salt)
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password.startswith(b'{SMD5}')
 
@@ -347,7 +348,7 @@ class MD5PasswordManager(PlainTextPasswordManager):
             md5(_encoder(password)[0]).digest())
 
     def checkPassword(self, encoded_password, password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         encoded = encoded_password[encoded_password.find(b'}') + 1:]
         if len(encoded) > 24:
@@ -356,7 +357,7 @@ class MD5PasswordManager(PlainTextPasswordManager):
         return encoded == self.encodePassword(password)[5:]
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password.startswith(b'{MD5}')
 
@@ -437,7 +438,7 @@ class SHA1PasswordManager(PlainTextPasswordManager):
             sha1(_encoder(password)[0]).digest())
 
     def checkPassword(self, encoded_password, password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         if self.match(encoded_password):
             encoded = encoded_password[encoded_password.find(b'}') + 1:]
@@ -450,11 +451,117 @@ class SHA1PasswordManager(PlainTextPasswordManager):
         return encoded_password == self.encodePassword(password)[5:]
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return (
             encoded_password.startswith(b'{SHA}') or
             encoded_password.startswith(b'{SHA1}'))
+
+
+if bcrypt is not None:
+
+        class BCRYPTPasswordManager(PlainTextPasswordManager):
+            """BCRYPT password manager.
+
+            >>> from zope.interface.verify import verifyObject
+            >>> from zope.password.interfaces import IMatchingPasswordManager
+            >>> from zope.password.password import BCRYPTPasswordManager
+
+            >>> manager = BCRYPTPasswordManager()
+            >>> verifyObject(IMatchingPasswordManager, manager)
+            True
+
+            # Hashing a password for the first time, with a
+            # randomly-generated salt
+            >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
+            >>> encoded = manager.encodePassword(password)
+            >>> manager.match(encoded)
+            True
+            >>> manager.checkPassword(encoded, password)
+            True
+            >>> manager.checkPassword(encoded, password + u"wrong")
+            False
+
+            # Subsequently hashing the same password will produce a
+            # different encoding
+            >>> encoded2 = manager.encodePassword(password)
+            >>> encoded2 != encoded
+            True
+
+            # Both matching and checking will work against both
+            >>> manager.match(encoded)
+            True
+            >>> manager.match(encoded2)
+            True
+            >>> manager.checkPassword(encoded, password)
+            True
+            >>> manager.checkPassword(encoded2, password)
+            True
+            >>> manager.checkPassword(encoded2, password + u"wrong")
+            False
+
+            """
+            _prefix = b'{BCRYPT}'
+
+            def _to_bytes(self, password, encoding):
+                if isinstance(password, text_type):
+                    return password.encode(encoding)
+                return password
+
+            def _clean_clear(self, password):
+                return self._to_bytes(password, 'utf-8')
+
+            def _clean_hashed(self, hashed_password):
+                return self._to_bytes(hashed_password, 'ascii')
+
+            gensalt = staticmethod(bcrypt.gensalt)
+
+            def checkPassword(self, hashed_password, clear_password):
+                """Check a `hashed_password` against a `clear password`.
+
+                :param hashed_password: The encoded password.
+                :type hashed_password: str
+                :param clear_password: The password to check.
+                :type clear_password: unicode
+                :returns: True iif hashed passwords are equal.
+                :rtype: bool
+                """
+                if not self.match(hashed_password):
+                    return False
+                pw_bytes = self._clean_clear(clear_password)
+                pw_hash = hashed_password[len(self._prefix):]
+                try:
+                    return bcrypt.hashpw(pw_bytes, pw_hash) == pw_hash
+                except ValueError:
+                    return False
+
+            def encodePassword(self, password, salt=None):
+                """Encode a `password`, with an optional `salt`.
+
+                If `salt` is not provided, a unique hash will be generated
+                for each invokation.
+
+                :param password: The clear-text password.
+                :type password: unicode
+                :param salt: The salt to be used to hash the password.
+                :rtype: str
+                :returns: The encoded password as a byte-siring.
+                """
+                if salt is None:
+                    salt = self.gensalt()
+                salt = self._clean_hashed(salt)
+                pw = self._clean_clear(password)
+                return self._prefix + bcrypt.hashpw(pw, salt=salt)
+
+            def match(self, hashed_password):
+                """Was the password hashed with this password manager.
+
+                :param hashed_password: The encoded password.
+                :type hashed_password: str
+                :rtype: bool
+                :returns: True iif the password was hashed with this manager.
+                """
+                return hashed_password.startswith(self._prefix)
 
 
 # Simple registry
@@ -465,3 +572,6 @@ managers = [
     ('SHA1', SHA1PasswordManager()),
     ('SSHA', SSHAPasswordManager()),
 ]
+
+if bcrypt is not None:
+    managers.append(('BCRYPT', BCRYPTPasswordManager()))

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2009 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
+#
 # This software is subject to the provisions of the Zope Public License,
 # Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
 # THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
@@ -37,80 +38,108 @@ checker = renormalizing.RENormalizing([
      r"\1"),
     ])
 
-if bcrypt is not None:
 
-    class TestBCRYPTPasswordManager(unittest.TestCase):
-        """Tests for custom zope.password password manager."""
+skip_if_bcrypt_not_installed = unittest.skipIf(
+    bcrypt is None,
+    'bcrypt is not installed')
 
-        password = (
-            u'Close \N{GREEK SMALL LETTER PHI}ncounterS 0f '
-            u'tHe Erd K1nd'
+
+class TestBCRYPTPasswordManager(unittest.TestCase):
+    """Tests for custom zope.password password manager."""
+
+    password = (
+        u'Close \N{GREEK SMALL LETTER PHI}ncounterS 0f '
+        u'tHe Erd K1nd'
+    )
+
+    def _make_one(self):
+        from zope.password.password import BCRYPTPasswordManager
+        return BCRYPTPasswordManager()
+
+    @contextlib.contextmanager
+    def _encode_twice(self, pw_mgr, salt1=None, salt2=None):
+        enc_pw1 = pw_mgr.encodePassword(self.password, salt=salt1)
+        enc_pw2 = pw_mgr.encodePassword(self.password, salt=salt2)
+        yield (enc_pw1, enc_pw2)
+        for enc_pw in (enc_pw1, enc_pw2):
+            self.assertTrue(enc_pw.startswith(b'{BCRYPT}'))
+            self.assertTrue(isinstance(enc_pw, bytes_type))
+
+    @skip_if_bcrypt_not_installed
+    def test_interface_compliance(self):
+        pw_mgr = self._make_one()
+        verifyObject(IMatchingPasswordManager, pw_mgr)
+
+    @skip_if_bcrypt_not_installed
+    def test_encodePassword_with_no_salt(self):
+        pw_mgr = self._make_one()
+        with self._encode_twice(pw_mgr,
+                                salt1=None,
+                                salt2=None) as encoded_passwords:
+            self.assertNotEqual(*encoded_passwords)
+
+    @skip_if_bcrypt_not_installed
+    def test_encodePassword_with_same_salt(self):
+        pw_mgr = self._make_one()
+        salt = bcrypt.gensalt()
+        with self._encode_twice(pw_mgr,
+                                salt1=salt,
+                                salt2=salt) as encoded_passwords:
+            self.assertEqual(*encoded_passwords)
+
+    @skip_if_bcrypt_not_installed
+    def test_encodePassword_with_different_salts(self):
+        pw_mgr = self._make_one()
+        salt = bcrypt.gensalt()
+        with self._encode_twice(pw_mgr,
+                                salt1=salt,
+                                salt2=None) as encoded_passwords:
+            self.assertNotEqual(*encoded_passwords)
+        with self._encode_twice(pw_mgr,
+                                salt1=None,
+                                salt2=salt) as encoded_passwords:
+            self.assertNotEqual(*encoded_passwords)
+
+    @skip_if_bcrypt_not_installed
+    def test_encodePassword_with_unicode_salts(self):
+        pw_mgr = self._make_one()
+        salt = bcrypt.gensalt()
+        # *handle* unicode salts (since all other encoding is handled)
+        with self._encode_twice(pw_mgr,
+                                salt1=text_type(salt, 'utf-8'),
+                                salt2=salt) as encoded_passwords:
+            self.assertEqual(*encoded_passwords)
+
+    @skip_if_bcrypt_not_installed
+    def test_checkPassword(self):
+        encoded = (
+            b'{BCRYPT}'
+            b'$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK'
         )
+        pw_mgr = self._make_one()
+        self.assertTrue(pw_mgr.checkPassword(encoded, self.password))
+        # Mess with the hashed password, should not match
+        encoded = encoded[:-1]
+        self.assertFalse(pw_mgr.checkPassword(encoded, self.password))
 
-        def _make_one(self):
-            from zope.password.password import BCRYPTPasswordManager
-            return BCRYPTPasswordManager()
+        password = u"right \N{CYRILLIC CAPITAL LETTER A}"
+        encoded = pw_mgr.encodePassword(password)
+        self.assertTrue(pw_mgr.checkPassword(encoded, password))
+        self.assertFalse(pw_mgr.checkPassword(encoded, password + u"wrong"))
 
-        def test_interface_compliance(self):
-            pw_mgr = self._make_one()
-            verifyObject(IMatchingPasswordManager, pw_mgr)
+        # Subsequently hashing the same password will produce a
+        # different encoding
+        encoded2 = pw_mgr.encodePassword(password)
+        self.assertNotEqual(encoded2, encoded)
+        self.assertFalse(pw_mgr.checkPassword(encoded2, password + u"wrong"))
+        self.assertTrue(pw_mgr.checkPassword(encoded, password))
+        self.assertTrue(pw_mgr.checkPassword(encoded2, password))
 
-        @contextlib.contextmanager
-        def _encode_twice(self, pw_mgr, salt1=None, salt2=None):
-            enc_pw1 = pw_mgr.encodePassword(self.password, salt=salt1)
-            enc_pw2 = pw_mgr.encodePassword(self.password, salt=salt2)
-            yield (enc_pw1, enc_pw2)
-            for enc_pw in (enc_pw1, enc_pw2):
-                self.assertTrue(enc_pw.startswith(b'{BCRYPT}'))
-                self.assertTrue(isinstance(enc_pw, bytes_type))
-
-        def test_encodePassword_with_salt(self):
-            pw_mgr = self._make_one()
-
-            # No salt
-            with self._encode_twice(pw_mgr,
-                                    salt1=None,
-                                    salt2=None) as encoded_passwords:
-                self.assertNotEqual(*encoded_passwords)
-
-            # Same salt
-            salt = bcrypt.gensalt()
-            with self._encode_twice(pw_mgr,
-                                    salt1=salt,
-                                    salt2=salt) as encoded_passwords:
-                self.assertEqual(*encoded_passwords)
-
-            # different salts
-            with self._encode_twice(pw_mgr,
-                                    salt1=salt,
-                                    salt2=None) as encoded_passwords:
-                self.assertNotEqual(*encoded_passwords)
-            with self._encode_twice(pw_mgr,
-                                    salt1=None,
-                                    salt2=salt) as encoded_passwords:
-                self.assertNotEqual(*encoded_passwords)
-
-            # *handle* unicode salts (since all other encoding is handled)
-            with self._encode_twice(pw_mgr,
-                                    salt1=text_type(salt, 'utf-8'),
-                                    salt2=salt) as encoded_passwords:
-                self.assertEqual(*encoded_passwords)
-
-        def test_checkPassword(self):
-            encoded = (
-                b'{BCRYPT}'
-                b'$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK'
-            )
-            pw_mgr = self._make_one()
-            self.assertTrue(pw_mgr.checkPassword(encoded, self.password))
-            # Mess with the hashed password, should not match
-            encoded = encoded[:-1]
-            self.assertFalse(pw_mgr.checkPassword(encoded, self.password))
-
-        def test_match(self):
-            pw_mgr = self._make_one()
-            self.assertFalse(pw_mgr.match(b'{SHA1}1lksd;kf;slkf;slkf'))
-            self.assertTrue(pw_mgr.match(b'{BCRYPT}'))
+    @skip_if_bcrypt_not_installed
+    def test_match(self):
+        pw_mgr = self._make_one()
+        self.assertFalse(pw_mgr.match(b'{SHA1}1lksd;kf;slkf;slkf'))
+        self.assertTrue(pw_mgr.match(b'{BCRYPT}'))
 
 
 def test_suite():
@@ -121,6 +150,5 @@ def test_suite():
             'zope.password.testing',
             optionflags=doctest.ELLIPSIS, checker=checker),
         ))
-    if bcrypt is not None:
-        suite.addTests(unittest.defaultTestLoader.loadTestsFromName(__name__))
+    suite.addTests(unittest.defaultTestLoader.loadTestsFromName(__name__))
     return suite

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -13,10 +13,21 @@
 ##############################################################################
 """Password Managers Tests
 """
+import contextlib
 import doctest
 import re
 import unittest
+
+try:
+    import bcrypt
+except ImportError:
+    bcrypt = None
+
+from zope.interface.verify import verifyObject
 from zope.testing import renormalizing
+
+from zope.password.interfaces import IMatchingPasswordManager
+from zope.password.compat import bytes_type, text_type
 
 checker = renormalizing.RENormalizing([
     # Python 3 bytes add a "b".
@@ -26,11 +37,89 @@ checker = renormalizing.RENormalizing([
      r"\1"),
     ])
 
+if bcrypt is not None:
+
+    class TestBCRYPTPasswordManager(unittest.TestCase):
+        """Tests for custom zope.password password manager."""
+
+        password = (
+            u'Close \N{GREEK SMALL LETTER PHI}ncounterS 0f '
+            u'tHe Erd K1nd'
+        )
+
+        def _make_one(self):
+            from zope.password.password import BCRYPTPasswordManager
+            return BCRYPTPasswordManager()
+
+        def test_interface_compliance(self):
+            pw_mgr = self._make_one()
+            verifyObject(IMatchingPasswordManager, pw_mgr)
+
+        @contextlib.contextmanager
+        def _encode_twice(self, pw_mgr, salt1=None, salt2=None):
+            enc_pw1 = pw_mgr.encodePassword(self.password, salt=salt1)
+            enc_pw2 = pw_mgr.encodePassword(self.password, salt=salt2)
+            yield (enc_pw1, enc_pw2)
+            for enc_pw in (enc_pw1, enc_pw2):
+                self.assertTrue(enc_pw.startswith(b'{BCRYPT}'))
+                self.assertTrue(isinstance(enc_pw, bytes_type))
+
+        def test_encodePassword_with_salt(self):
+            pw_mgr = self._make_one()
+
+            # No salt
+            with self._encode_twice(pw_mgr,
+                                    salt1=None,
+                                    salt2=None) as encoded_passwords:
+                self.assertNotEqual(*encoded_passwords)
+
+            # Same salt
+            salt = bcrypt.gensalt()
+            with self._encode_twice(pw_mgr,
+                                    salt1=salt,
+                                    salt2=salt) as encoded_passwords:
+                self.assertEqual(*encoded_passwords)
+
+            # different salts
+            with self._encode_twice(pw_mgr,
+                                    salt1=salt,
+                                    salt2=None) as encoded_passwords:
+                self.assertNotEqual(*encoded_passwords)
+            with self._encode_twice(pw_mgr,
+                                    salt1=None,
+                                    salt2=salt) as encoded_passwords:
+                self.assertNotEqual(*encoded_passwords)
+
+            # *handle* unicode salts (since all other encoding is handled)
+            with self._encode_twice(pw_mgr,
+                                    salt1=text_type(salt, 'utf-8'),
+                                    salt2=salt) as encoded_passwords:
+                self.assertEqual(*encoded_passwords)
+
+        def test_checkPassword(self):
+            encoded = (
+                b'{BCRYPT}'
+                b'$2b$12$ez4eHl6W1PfAWix5bPIbe.drdnyqjpuT1Cp0N.xcdxkAEbA7K6AHK'
+            )
+            pw_mgr = self._make_one()
+            self.assertTrue(pw_mgr.checkPassword(encoded, self.password))
+            encoded += b'wrong'
+            self.assertFalse(pw_mgr.checkPassword(encoded, self.password))
+
+        def test_match(self):
+            pw_mgr = self._make_one()
+            self.assertFalse(pw_mgr.match(b'{SHA1}1lksd;kf;slkf;slkf'))
+            self.assertTrue(pw_mgr.match(b'{BCRYPT}'))
+
+
 def test_suite():
-    return unittest.TestSuite((
+    suite = unittest.TestSuite((
         doctest.DocTestSuite('zope.password.password', checker=checker),
         doctest.DocTestSuite('zope.password.legacy', checker=checker),
         doctest.DocTestSuite(
             'zope.password.testing',
             optionflags=doctest.ELLIPSIS, checker=checker),
         ))
+    if bcrypt is not None:
+        suite.addTests(unittest.defaultTestLoader.loadTestsFromName(__name__))
+    return suite

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -103,7 +103,8 @@ if bcrypt is not None:
             )
             pw_mgr = self._make_one()
             self.assertTrue(pw_mgr.checkPassword(encoded, self.password))
-            encoded += b'wrong'
+            # Mess with the hashed password, should not match
+            encoded = encoded[:-1]
             self.assertFalse(pw_mgr.checkPassword(encoded, self.password))
 
         def test_match(self):

--- a/src/zope/password/tests/test_zpasswd.py
+++ b/src/zope/password/tests/test_zpasswd.py
@@ -13,10 +13,10 @@
 ##############################################################################
 """Tests for the zpasswd script.
 """
-
+import doctest
 import os
 import sys
-import unittest, doctest
+import unittest
 
 try:
     from StringIO import StringIO
@@ -25,6 +25,7 @@ except ImportError:
     from io import StringIO
 
 from zope.password import password, zpasswd
+
 
 class TestBase(unittest.TestCase):
     def setUp(self):
@@ -59,7 +60,7 @@ class ArgumentParsingTestCase(TestBase):
 
     def check_stdout_content(self, args):
         try:
-            options = self.parse_args(args)
+            self.parse_args(args)
         except SystemExit as e:
             self.assertEqual(e.code, 0)
             self.assertTrue(self.stdout.getvalue())

--- a/src/zope/password/zpasswd.py
+++ b/src/zope/password/zpasswd.py
@@ -249,7 +249,7 @@ def get_password_managers(config_path=None):
         from zope.password.interfaces import IPasswordManager
 
         print("Loading configuration...")
-        config = xmlconfig.file(config_path)
+        xmlconfig.file(config_path)
         managers = []
         for name, manager in getUtilitiesFor(IPasswordManager):
             if name == "Plain Text":

--- a/src/zope/password/zpasswd.py
+++ b/src/zope/password/zpasswd.py
@@ -144,7 +144,7 @@ class Application(object):
         except KeyboardInterrupt:
             # The cursor was left on the same line as the prompt,
             # which we don't like.  Print a blank line.
-            print
+            print()
             raise
 
     def process(self):
@@ -191,7 +191,7 @@ class Application(object):
     def get_password_manager(self):
         default = 0
         self.print_message("Password manager:")
-        print
+        print()
         managers = self.options.managers
 
         for i, (name, manager) in enumerate(managers):
@@ -200,7 +200,7 @@ class Application(object):
                 default = i
             elif name == 'SSHA' and not default:
                 default = i
-        print
+        print()
         self.need_blank_line = True
         while True:
             password_manager = self.read_input_line(
@@ -236,7 +236,7 @@ class Application(object):
 
     def print_message(self, message):
         if self.need_blank_line:
-            print
+            print()
             self.need_blank_line = False
         print(message)
 

--- a/src/zope/password/zpasswd.py
+++ b/src/zope/password/zpasswd.py
@@ -196,7 +196,9 @@ class Application(object):
 
         for i, (name, manager) in enumerate(managers):
             print("% i. %s" % (i + 1, name))
-            if name == 'SSHA':
+            if name == 'BCRYPT':
+                default = i
+            elif name == 'SSHA' and not default:
                 default = i
         print
         self.need_blank_line = True

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,18 @@ envlist =
 
 [testenv]
 commands =
+    py{26,27,33,34}: pip install -qe ".[test,bcrypt]"
     python setup.py -q test -q
 # without explicit deps, setup.py test will download a bunch of eggs into $PWD
 # (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
 deps =
+    py{26,27,33,34}--docs: bcrypt
     zope.component
     zope.configuration
     zope.interface
     zope.schema
     zope.testing
     zope.testrunner
-
 
 [testenv:docs]
 basepython =


### PR DESCRIPTION
@mgedmin @tseaver 
This should supersede #1, in which I had hastily deleted the fork that #1 was based on.

Main difference is now it uses the `bcrypt.checkpw()` API (2369754).
Based on related modifications recently made to a similar PR in [AuthEncoding](/zopefoundation/AuthEncoding/pull/1/commits/db76353071f28fa1ff02b7a02b602bd6fe418a18)