### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.password
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ develop-eggs
 parts
 docs/_build/
 dist/
+htmlcov/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - pypy
+    # Force a newer PyPy on the old 'precise' CI image.
+    # After September 2017 this should be the default and the version
+    # pin can be removed.
+    - pypy-5.6.0
     - pypy3.5-5.8.0
 install:
     - pip install -U pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-#   - pypy3
-#   pending 3.3-compatible release
+    - pypy3.5-5.8.0
 install:
-    - pip install .
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy'* ]]; then pip install bcrypt; fi
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test,docs]
 script:
-    - python setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,19 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.3.0 (unreleased)
-------------------
+==================
 
 - Added a ``bcrypt``-based password manager (available only if the ``bcrypt``
   library is importable).
 
+- Add support for Python 3.6.
+
+- Drop support for Python 3.3.
 
 4.2.0 (2016-07-07)
-------------------
+==================
 
 - Drop support for Python 2.6.
 
@@ -20,7 +24,7 @@ Changes
 
 
 4.1.0 (2014-12-27)
-------------------
+==================
 
 - Add support for PyPy.  (PyPy3 is pending release of a fix for:
   https://bitbucket.org/pypy/pypy/issue/1946)
@@ -31,19 +35,19 @@ Changes
 
 
 4.0.2 (2013-03-11)
-------------------
+==================
 
 - Fix some final resource warnings.
 
 
 4.0.1 (2013-03-10)
-------------------
+==================
 
 - Fix test failures under Python 3.3 when warnings are enabled.
 
 
 4.0.0 (2013-02-21)
-------------------
+==================
 
 - Make ``zpasswd`` a proper console script entry point.
 
@@ -84,7 +88,7 @@ Changes
   to maintain compatibility with LDAP.
 
 3.6.1 (2010-05-27)
-------------------
+==================
 
 - The SSHAPasswordManager.checkPassword() would not handle unicode input
   (even if the string would only contain ascii characters). Now, the
@@ -92,7 +96,7 @@ Changes
   as it should not contain non-ascii characters anyway.
 
 3.6.0 (2010-05-07)
-------------------
+==================
 
 - Remove ``zope.testing`` dependency for tests.
 
@@ -103,7 +107,7 @@ Changes
   manager, now SSHA is used as default.
 
 3.5.1 (2009-03-14)
-------------------
+==================
 
 - Make security protection directives in ``configure.zcml`` execute only
   if ``zope.security`` is installed. This will allow reuse of the
@@ -116,7 +120,7 @@ Changes
   "vocabulary" extra to list dependencies needed for vocabulary functionality.
 
 3.5.0 (2009-03-06)
-------------------
+==================
 
 First release. This package was splitted off from ``zope.app.authentication``
 to separate password manager functionality that is greatly re-usable without

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@
 
 - Drop support for Python 3.3.
 
+- Fix the ``zpasswd`` console script on Python 3.
+
 4.2.0 (2016-07-07)
 ==================
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,13 @@ include *.txt
 include *.py
 include buildout.cfg
 include tox.ini
+include .coveragerc
+include .travis.yml
 
 recursive-include src *
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
 
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,17 +1,27 @@
-``zope.password``
-=================
+===================
+ ``zope.password``
+===================
 
 .. image:: https://img.shields.io/pypi/v/zope.password.svg
-    :target: https://pypi.python.org/pypi/zope.password/
-    :alt: Latest Version
+        :target: https://pypi.python.org/pypi/zope.password/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.password.svg
+        :target: https://pypi.org/project/zope.password/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.password.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.password
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.password/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.password?branch=master
+
 .. image:: https://readthedocs.org/projects/zopepassword/badge/?version=latest
-        :target: http://zopepassword.readthedocs.org/en/latest/
+        :target: https://zopepassword.readthedocs.io/en/latest/
         :alt: Documentation Status
 
 This package provides a password manager mechanism. Password manager
 is an utility object that can encode and check encoded
 passwords.
+
+Documentation is hosted at https://zopepassword.readthedocs.io/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,9 @@
-:mod:`zope.password` API
-========================
+==========================
+ :mod:`zope.password` API
+==========================
 
 Interfaces
-----------
+==========
 
 .. automodule:: zope.password.interfaces
    :members:
@@ -10,7 +11,7 @@ Interfaces
 
 
 Password Manager Implementations
---------------------------------
+================================
 
 .. automodule:: zope.password.password
    :members:
@@ -18,7 +19,7 @@ Password Manager Implementations
 
 
 Deprecated Implementations
-##########################
+--------------------------
 
 .. warning::
 
@@ -33,7 +34,7 @@ Deprecated Implementations
 
 
 Vocabulary
-----------
+==========
 
 .. automodule:: zope.password.vocabulary
    :members:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,19 @@ def alltests():
     suites = list(zope.testrunner.find.find_suites(options))
     return unittest.TestSuite(suites)
 
+VOCABULARY_REQUIRES = [
+    'zope.schema',
+]
+
+BCRYPT_REQUIRES = [
+    'bcrypt',
+]
+
+TESTS_REQUIRE = VOCABULARY_REQUIRES + BCRYPT_REQUIRES + [
+    'zope.testing',
+    'zope.testrunner',
+]
+
 setup(name='zope.password',
       version='4.3.0.dev0',
       author='Zope Foundation and Contributors',
@@ -44,10 +57,10 @@ setup(name='zope.password',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
-      url='http://pypi.python.org/pypi/zope.password',
+      ),
+      url='http://github.com/zopefoundation/zope.password',
       license='ZPL 2.1',
-      classifiers = [
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -56,33 +69,36 @@ setup(name='zope.password',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
+          'Framework :: Zope3',
+      ],
       keywords='zope authentication password zpasswd',
       packages=find_packages('src'),
       package_dir={'': 'src'},
-      extras_require=dict(vocabulary=['zope.schema'],
-                          test=['zope.schema', 'zope.testing'],
-                          bcrypt=['bcrypt'],
-                          ),
+      extras_require={
+          'vocabulary': VOCABULARY_REQUIRES,
+          'test': TESTS_REQUIRE,
+          'bcrypt': BCRYPT_REQUIRES,
+          'docs': [
+              'Sphinx',
+              'repoze.sphinx.autointerface',
+          ]
+      },
       namespace_packages=['zope'],
-      install_requires=['setuptools',
-                        'zope.component',
-                        'zope.configuration',
-                        'zope.interface',
-                        ],
-      tests_require=[
-          'zope.schema',
-          'zope.testing',
-          'zope.testrunner',
-          ],
+      install_requires=[
+          'setuptools',
+          'zope.component',
+          'zope.configuration',
+          'zope.interface',
+      ],
+      tests_require=TESTS_REQUIRE,
       test_suite='__main__.alltests',
       include_package_data=True,
       zip_safe=False,
@@ -90,4 +106,4 @@ setup(name='zope.password',
       [console_scripts]
       zpasswd = zope.password.zpasswd:main
       """,
-      )
+)

--- a/src/zope/password/compat.py
+++ b/src/zope/password/compat.py
@@ -2,9 +2,5 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
-if PY3:
-    text_type = str
-    bytes_type = bytes
-else:
-    text_type = unicode
-    bytes_type = str
+text_type = str if bytes is not str else unicode
+bytes_type = bytes

--- a/src/zope/password/compat.py
+++ b/src/zope/password/compat.py
@@ -1,6 +1,0 @@
-import sys
-
-PY3 = sys.version_info[0] == 3
-
-text_type = str if bytes is not str else unicode
-bytes_type = bytes

--- a/src/zope/password/legacy.py
+++ b/src/zope/password/legacy.py
@@ -26,7 +26,6 @@ except ImportError: # pragma: no cover
 
 from zope.interface import implementer
 from zope.password.interfaces import IMatchingPasswordManager
-from zope.password.compat import text_type
 
 _encoder = getencoder("utf-8")
 
@@ -214,11 +213,11 @@ class MySQLPasswordManager(object):
         return ("{MYSQL}%08lx%08lx" % (r0, r1)).encode()
 
     def checkPassword(self, encoded_password, password):
-        if isinstance(encoded_password, text_type):
+        if not isinstance(encoded_password, bytes):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password == self.encodePassword(password)
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, text_type):
+        if not isinstance(encoded_password, bytes):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password.startswith(b'{MYSQL}')

--- a/src/zope/password/legacy.py
+++ b/src/zope/password/legacy.py
@@ -20,22 +20,17 @@ from codecs import getencoder
 try:
     from crypt import crypt
     from random import choice
-except ImportError:
+except ImportError: # pragma: no cover
     # The crypt module is not universally available, apparently
     crypt = None
 
 from zope.interface import implementer
 from zope.password.interfaces import IMatchingPasswordManager
+from zope.password.compat import text_type
 
 _encoder = getencoder("utf-8")
 
 PY2 = sys.version_info[0] == 2
-
-try:
-    unicode
-except NameError:
-    # Py3: Define unicode.
-    unicode = str
 
 
 if crypt is not None:
@@ -156,6 +151,10 @@ class MySQLPasswordManager(object):
     {MYSQL}0ecd752c5097d395
     >>> manager.match(encoded)
     True
+    >>> manager.match(encoded.decode())
+    True
+    >>> manager.checkPassword(encoded.decode(), password)
+    True
     >>> manager.checkPassword(encoded, password)
     True
     >>> manager.checkPassword(encoded, password + u"wrong")
@@ -165,7 +164,7 @@ class MySQLPasswordManager(object):
     hash ``379693e271cd3bd6``, according to
     http://phpsec.org/articles/2005/password-hashing.html
 
-    Our password manager generates the same value when seeded with the, so we
+    Our password manager generates the same value when seeded with the same seed, so we
     can be sure, our output is compatible with MySQL versions before 4.1:
 
     >>> password = 'PHP & Information Security'
@@ -186,6 +185,14 @@ class MySQLPasswordManager(object):
     >>> manager.match('{MD5}someotherhash')
     False
 
+    Spaces and tabs are ignored:
+
+    >>> encoded = manager.encodePassword('\tign or ed')
+    >>> print(encoded.decode())
+    {MYSQL}75818366052c6a78
+    >>> encoded = manager.encodePassword('ignored')
+    >>> print(encoded.decode())
+    {MYSQL}75818366052c6a78
     """
 
 
@@ -198,7 +205,7 @@ class MySQLPasswordManager(object):
                 # In Python 2 bytes iterate over single-char strings.
                 i = ord(i)
             if i == ord(b' ') or i == ord(b'\t'):
-                continue
+                continue # pragma: no cover (this is actually hit, but coverage isn't reporting it)
             nr ^= (((nr & 63) + add) * i) + (nr << 8)
             nr2 += (nr2 << 8) ^ nr
             add += i
@@ -207,11 +214,11 @@ class MySQLPasswordManager(object):
         return ("{MYSQL}%08lx%08lx" % (r0, r1)).encode()
 
     def checkPassword(self, encoded_password, password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password == self.encodePassword(password)
 
     def match(self, encoded_password):
-        if isinstance(encoded_password, unicode):
+        if isinstance(encoded_password, text_type):
             encoded_password = encoded_password.encode('ascii')
         return encoded_password.startswith(b'{MYSQL}')

--- a/src/zope/password/legacy.py
+++ b/src/zope/password/legacy.py
@@ -64,6 +64,12 @@ if crypt is not None:
         >>> manager.checkPassword(encoded, password)
         True
 
+        Note that this object fails to return bytes from the ``encodePassword``
+        function on Python 3:
+
+        >>> isinstance(encoded, str)
+        True
+
         Unfortunately, crypt only looks at the first 8 characters, so matching
         against an 8 character password plus suffix always matches. Our test
         password (including utf-8 encoding) is exactly 8 characters long, and
@@ -120,7 +126,7 @@ if crypt is not None:
 
         def checkPassword(self, encoded_password, password):
             return encoded_password == self.encodePassword(password,
-                encoded_password[7:9])
+                                                           encoded_password[7:9])
 
         def match(self, encoded_password):
             return encoded_password.startswith('{CRYPT}')
@@ -144,8 +150,10 @@ class MySQLPasswordManager(object):
 
     >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
     >>> encoded = manager.encodePassword(password)
-    >>> encoded
-    '{MYSQL}0ecd752c5097d395'
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {MYSQL}0ecd752c5097d395
     >>> manager.match(encoded)
     True
     >>> manager.checkPassword(encoded, password)
@@ -162,8 +170,10 @@ class MySQLPasswordManager(object):
 
     >>> password = 'PHP & Information Security'
     >>> encoded = manager.encodePassword(password)
-    >>> encoded
-    '{MYSQL}379693e271cd3bd6'
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {MYSQL}379693e271cd3bd6
 
     >>> manager.checkPassword(encoded, password)
     True

--- a/src/zope/password/password.py
+++ b/src/zope/password/password.py
@@ -25,7 +25,7 @@ from os import urandom
 
 try:
     import bcrypt
-except ImportError:
+except ImportError: # pragma: no cover
     bcrypt = None
 
 from zope.interface import implementer
@@ -112,6 +112,8 @@ class SSHAPasswordManager(PlainTextPasswordManager):
 
     >>> manager.match(encoded)
     True
+    >>> manager.match(encoded.decode())
+    True
     >>> manager.checkPassword(encoded, password)
     True
     >>> manager.checkPassword(encoded, password + u"wrong")
@@ -137,6 +139,16 @@ class SSHAPasswordManager(PlainTextPasswordManager):
     True
     >>> manager.checkPassword(encoded, password + u"wrong")
     False
+
+    We can also pass a salt that is a text string:
+
+    >>> salt = u'salt'
+    >>> password = 'secret'
+    >>> encoded = manager.encodePassword(password, salt)
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SSHA}gVK8WC9YyFT1gMsQHTGCgT3sSv5zYWx0
 
     Because a random salt is generated, the output of encodePassword is
     different every time you call it.
@@ -224,6 +236,8 @@ class SMD5PasswordManager(PlainTextPasswordManager):
 
     >>> manager.match(encoded)
     True
+    >>> manager.match(encoded.decode())
+    True
     >>> manager.checkPassword(encoded, password)
     True
     >>> manager.checkPassword(encoded, password + u"wrong")
@@ -249,6 +263,16 @@ class SMD5PasswordManager(PlainTextPasswordManager):
     True
     >>> manager.checkPassword(encoded, password + u"wrong")
     False
+
+    We can also pass a salt that is a text string:
+
+    >>> salt = u'salt'
+    >>> password = 'secret'
+    >>> encoded = manager.encodePassword(password, salt)
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SMD5}mc0uWpXVVe5747A4pKhGJXNhbHQ=
 
     Because a random salt is generated, the output of encodePassword is
     different every time you call it.
@@ -312,6 +336,8 @@ class MD5PasswordManager(PlainTextPasswordManager):
     >>> print(encoded.decode())
     {MD5}ht3czsRdtFmfGsAAGOVBOQ==
     >>> manager.match(encoded)
+    True
+    >>> manager.match(encoded.decode())
     True
     >>> manager.checkPassword(encoded, password)
     True
@@ -390,6 +416,8 @@ class SHA1PasswordManager(PlainTextPasswordManager):
     >>> print(encoded.decode())
     {SHA}BLTuxxVMXzouxtKVb7gLgNxzdAI=
     >>> manager.match(encoded)
+    True
+    >>> manager.match(encoded.decode())
     True
     >>> manager.checkPassword(encoded, password)
     True
@@ -489,6 +517,11 @@ class BCRYPTPasswordManager(PlainTextPasswordManager):
     def checkPassword(self, hashed_password, clear_password):
         """Check a `hashed_password` against a `clear password`.
 
+        >>> from zope.password.password import BCRYPTPasswordManager
+        >>> manager = BCRYPTPasswordManager()
+        >>> manager.checkPassword(b'not from here', None)
+        False
+
         :param hashed_password: The encoded password.
         :type hashed_password: str
         :param clear_password: The password to check.
@@ -502,7 +535,7 @@ class BCRYPTPasswordManager(PlainTextPasswordManager):
         pw_hash = hashed_password[len(self._prefix):]
         try:
             ok = bcrypt.checkpw(pw_bytes, pw_hash)
-        except ValueError:
+        except ValueError: # pragma: no cover
             # invalid salt
             ok = False
         return ok
@@ -526,7 +559,7 @@ class BCRYPTPasswordManager(PlainTextPasswordManager):
         return self._prefix + bcrypt.hashpw(pw, salt=salt)
 
     def match(self, hashed_password):
-        """Was the password hashed with this password manager.
+        """Was the password hashed with this password manager?
 
         :param hashed_password: The encoded password.
         :type hashed_password: str

--- a/src/zope/password/password.py
+++ b/src/zope/password/password.py
@@ -105,8 +105,10 @@ class SSHAPasswordManager(PlainTextPasswordManager):
 
     >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
     >>> encoded = manager.encodePassword(password, salt="")
-    >>> encoded
-    '{SSHA}BLTuxxVMXzouxtKVb7gLgNxzdAI='
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SSHA}BLTuxxVMXzouxtKVb7gLgNxzdAI=
 
     >>> manager.match(encoded)
     True
@@ -126,8 +128,10 @@ class SSHAPasswordManager(PlainTextPasswordManager):
     >>> salt = standard_b64decode('ja/vZQ==')
     >>> password = 'secret'
     >>> encoded = manager.encodePassword(password, salt)
-    >>> encoded
-    '{SSHA}x3HIoiF9y6YRi/I4W1fkptbzTDiNr+9l'
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SSHA}x3HIoiF9y6YRi/I4W1fkptbzTDiNr+9l
 
     >>> manager.checkPassword(encoded, password)
     True
@@ -213,8 +217,10 @@ class SMD5PasswordManager(PlainTextPasswordManager):
 
     >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
     >>> encoded = manager.encodePassword(password, salt="")
-    >>> encoded
-    '{SMD5}ht3czsRdtFmfGsAAGOVBOQ=='
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SMD5}ht3czsRdtFmfGsAAGOVBOQ==
 
     >>> manager.match(encoded)
     True
@@ -234,8 +240,10 @@ class SMD5PasswordManager(PlainTextPasswordManager):
     >>> salt = standard_b64decode('9XkpYA==')
     >>> password = 'secret'
     >>> encoded = manager.encodePassword(password, salt)
-    >>> encoded
-    '{SMD5}zChC6x0tl2zr9fjvjZzKePV5KWA='
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SMD5}zChC6x0tl2zr9fjvjZzKePV5KWA=
 
     >>> manager.checkPassword(encoded, password)
     True
@@ -299,8 +307,10 @@ class MD5PasswordManager(PlainTextPasswordManager):
 
     >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
     >>> encoded = manager.encodePassword(password)
-    >>> encoded
-    '{MD5}ht3czsRdtFmfGsAAGOVBOQ=='
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {MD5}ht3czsRdtFmfGsAAGOVBOQ==
     >>> manager.match(encoded)
     True
     >>> manager.checkPassword(encoded, password)
@@ -313,8 +323,8 @@ class MD5PasswordManager(PlainTextPasswordManager):
     a MD5 hashing of ``secret`` is ``{MD5}Xr4ilOzQ4PCOq3aQ0qbuaQ==``,
     and our implementation returns the same hash:
 
-    >>> manager.encodePassword('secret')
-    '{MD5}Xr4ilOzQ4PCOq3aQ0qbuaQ=='
+    >>> print(manager.encodePassword('secret').decode())
+    {MD5}Xr4ilOzQ4PCOq3aQ0qbuaQ==
 
     The password manager should be able to cope with unicode strings for input:
 
@@ -375,8 +385,10 @@ class SHA1PasswordManager(PlainTextPasswordManager):
 
     >>> password = u"right \N{CYRILLIC CAPITAL LETTER A}"
     >>> encoded = manager.encodePassword(password)
-    >>> encoded
-    '{SHA}BLTuxxVMXzouxtKVb7gLgNxzdAI='
+    >>> isinstance(encoded, bytes)
+    True
+    >>> print(encoded.decode())
+    {SHA}BLTuxxVMXzouxtKVb7gLgNxzdAI=
     >>> manager.match(encoded)
     True
     >>> manager.checkPassword(encoded, password)
@@ -389,8 +401,8 @@ class SHA1PasswordManager(PlainTextPasswordManager):
     a SHA hashing of ``secret`` is ``{SHA}5en6G6MezRroT3XKqkdPOmY/BfQ=``,
     and our implementation returns the same hash:
 
-    >>> manager.encodePassword('secret')
-    '{SHA}5en6G6MezRroT3XKqkdPOmY/BfQ='
+    >>> print(manager.encodePassword('secret').decode())
+    {SHA}5en6G6MezRroT3XKqkdPOmY/BfQ=
 
     The password manager should be able to cope with unicode strings for input:
 

--- a/src/zope/password/testing.py
+++ b/src/zope/password/testing.py
@@ -29,7 +29,7 @@ from zope.password.vocabulary import PasswordManagerNamesVocabulary
 
 try:
     from zope.password.legacy import CryptPasswordManager
-except ImportError:
+except ImportError: # pragma: no cover
     CryptPasswordManager = None
 
 

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -31,12 +31,7 @@ from zope.password.interfaces import IMatchingPasswordManager
 from zope.password.compat import bytes_type, text_type
 
 checker = renormalizing.RENormalizing([
-    # Python 3 bytes add a "b".
-    (re.compile("b('.*?')"),
-     r"\1"),
-    (re.compile('b(".*?")'),
-     r"\1"),
-    ])
+])
 
 
 skip_if_bcrypt_not_installed = unittest.skipIf(

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -21,18 +21,10 @@ import unittest
 import bcrypt
 
 from zope.interface.verify import verifyObject
-from zope.testing import renormalizing
 
 from zope.password.interfaces import IMatchingPasswordManager
-from zope.password.compat import bytes_type, text_type
 
-checker = renormalizing.RENormalizing([
-])
-
-
-skip_if_bcrypt_not_installed = unittest.skipIf(
-    bcrypt is None,
-    'bcrypt is not installed')
+text_type = str if bytes is not str else unicode
 
 
 class TestBCRYPTPasswordManager(unittest.TestCase):
@@ -54,14 +46,12 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
         yield (enc_pw1, enc_pw2)
         for enc_pw in (enc_pw1, enc_pw2):
             self.assertTrue(enc_pw.startswith(b'{BCRYPT}'))
-            self.assertTrue(isinstance(enc_pw, bytes_type))
+            self.assertTrue(isinstance(enc_pw, bytes))
 
-    @skip_if_bcrypt_not_installed
     def test_interface_compliance(self):
         pw_mgr = self._make_one()
         verifyObject(IMatchingPasswordManager, pw_mgr)
 
-    @skip_if_bcrypt_not_installed
     def test_encodePassword_with_no_salt(self):
         pw_mgr = self._make_one()
         with self._encode_twice(pw_mgr,
@@ -69,7 +59,6 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
                                 salt2=None) as encoded_passwords:
             self.assertNotEqual(*encoded_passwords)
 
-    @skip_if_bcrypt_not_installed
     def test_encodePassword_with_same_salt(self):
         pw_mgr = self._make_one()
         salt = bcrypt.gensalt()
@@ -78,7 +67,6 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
                                 salt2=salt) as encoded_passwords:
             self.assertEqual(*encoded_passwords)
 
-    @skip_if_bcrypt_not_installed
     def test_encodePassword_with_different_salts(self):
         pw_mgr = self._make_one()
         salt = bcrypt.gensalt()
@@ -91,7 +79,6 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
                                 salt2=salt) as encoded_passwords:
             self.assertNotEqual(*encoded_passwords)
 
-    @skip_if_bcrypt_not_installed
     def test_encodePassword_with_unicode_salts(self):
         pw_mgr = self._make_one()
         salt = bcrypt.gensalt()
@@ -101,7 +88,6 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
                                 salt2=salt) as encoded_passwords:
             self.assertEqual(*encoded_passwords)
 
-    @skip_if_bcrypt_not_installed
     def test_checkPassword(self):
         encoded = (
             b'{BCRYPT}'
@@ -126,7 +112,6 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
         self.assertTrue(pw_mgr.checkPassword(encoded, password))
         self.assertTrue(pw_mgr.checkPassword(encoded2, password))
 
-    @skip_if_bcrypt_not_installed
     def test_match(self):
         pw_mgr = self._make_one()
         self.assertFalse(pw_mgr.match(b'{SHA1}1lksd;kf;slkf;slkf'))
@@ -135,11 +120,11 @@ class TestBCRYPTPasswordManager(unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite((
-        doctest.DocTestSuite('zope.password.password', checker=checker),
-        doctest.DocTestSuite('zope.password.legacy', checker=checker),
+        doctest.DocTestSuite('zope.password.password'),
+        doctest.DocTestSuite('zope.password.legacy'),
         doctest.DocTestSuite(
             'zope.password.testing',
-            optionflags=doctest.ELLIPSIS, checker=checker),
+            optionflags=doctest.ELLIPSIS),
         ))
     suite.addTests(unittest.defaultTestLoader.loadTestsFromName(__name__))
     return suite

--- a/src/zope/password/tests/test_password.py
+++ b/src/zope/password/tests/test_password.py
@@ -16,13 +16,9 @@
 """
 import contextlib
 import doctest
-import re
 import unittest
 
-try:
-    import bcrypt
-except ImportError:
-    bcrypt = None
+import bcrypt
 
 from zope.interface.verify import verifyObject
 from zope.testing import renormalizing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,docs
+    py27,py34,py35,py36,pypy,pypy3,docs,coverage
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,30 @@
 [tox]
 envlist =
-#   pypy3 pending a 3.3-compatible release.
-#   py27,py33,py34,pypy,pypy3
-    py27,py33,py34,py35,pypy,docs
+    py27,py34,py35,py36,pypy,pypy3,docs
 
 [testenv]
 commands =
-    py{26,27,33,34}: pip install -qe ".[test,bcrypt]"
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    zope-testrunner --test-path=src []
+#    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 deps =
-    py{26,27,33,34}--docs: bcrypt
-    zope.component
-    zope.configuration
-    zope.interface
-    zope.schema
-    zope.testing
-    zope.testrunner
+    .[test,docs]
+
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    coverage run -m zope.testrunner --test-path=src
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report --fail-under=89
+deps =
+    {[testenv]deps}
+    coverage
 
 [testenv:docs]
 basepython =
     python2.7
 commands =
     sphinx-build -a -b html -d docs/_build/doctrees docs docs/_build/html
-    sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
 deps =
-    zope.component
-    zope.configuration
-    zope.interface
-    zope.schema
-    Sphinx
-    repoze.sphinx.autointerface
+    .[docs]

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 [testenv]
 commands =
     zope-testrunner --test-path=src []
-#    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 deps =
     .[test,docs]
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ basepython =
 commands =
     coverage run -m zope.testrunner --test-path=src
     coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
-    coverage report --fail-under=89
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
- Badges
- Universal wheel
- DRY deps
- Run all doctests on all Python versions
- Add a coverage environment and enable coveralls
- 100% coverage
- Fix zpasswd on Python 3 (name error on `raw_input` and printing strings to a file opened in bytes mode) Fixes #2.