### PR TITLE
Fix running configure.zcml when zope.security is installed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.3.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix running ``configure.zcml`` when ``zope.security`` is installed.
+  See `issue 15
+  <https://github.com/zopefoundation/zope.password/issues/15>`_.
 
 
 4.3.0 (2017-08-31)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ BCRYPT_REQUIRES = [
 ]
 
 TESTS_REQUIRE = VOCABULARY_REQUIRES + BCRYPT_REQUIRES + [
+    'zope.security',
     'zope.testing',
     'zope.testrunner',
 ]

--- a/src/zope/password/configure.zcml
+++ b/src/zope/password/configure.zcml
@@ -79,6 +79,7 @@
       />
 
   <configure zcml:condition="installed zope.security">
+    <include package="zope.security" file="meta.zcml" />
 
     <class class=".password.PlainTextPasswordManager">
       <allow interface=".interfaces.IMatchingPasswordManager" />


### PR DESCRIPTION
Add zope.security to the test requires to test this.

Fixes #15