### PR TITLE
chore: Replace pkg_resources with pep420 namespace package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace deprecated pkg_resources with importlib metadata
 
 
 6.0 (2025-01-14)

--- a/src/zope/password/zpasswd.py
+++ b/src/zope/password/zpasswd.py
@@ -17,12 +17,11 @@
 import argparse
 import os
 import sys
+from importlib.metadata import version
 from xml.sax.saxutils import quoteattr
 
-import pkg_resources
 
-
-VERSION = pkg_resources.get_distribution('zope.password').version
+VERSION = version('zope.password')
 
 
 def main(argv=None, app_factory=None):


### PR DESCRIPTION
The pkg_resources package is slated for removal as early as 2025-11-3